### PR TITLE
Provide IDiscourse interface to enable extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,10 @@ To create a new user, go to "Admin" > "Users" > "Send Invites" and enter an emai
    __discourse_count_cache_age__: how often to talk to the the Discourse API in seconds. 
    
    __discourse.debug__: instead of inserting the JS code to embed a Discourse topic, debugging information is displayed instead. This is useful when troubleshooting, as a misconfigured plugin will "spam" your discourse instance with topics that may annoy your users with false-positive discourse notifications.
+
+## Extending the discourse integration
+
+The discourse plugin provides a plugin interface called `IDiscourse`, which enables other extensions to extend the discourse integration.
+Currently only one method is available:
+
+* `before_render_comments`: called before the comments are rendered, please check the source of [`ckanext-discourse/ckanext/discourse/interfaces.py`](https://github.com/OpenGov-OpenData/ckanext-discourse/blob/master/ckanext/dcat/interfaces.py) for detailed information.

--- a/ckanext/discourse/interfaces.py
+++ b/ckanext/discourse/interfaces.py
@@ -1,0 +1,31 @@
+from ckan.plugins.interfaces import Interface
+
+
+class IDiscourse(Interface):
+
+    def before_render_comments(self, data, pkg_dict):
+        '''
+        Called just before the discourse comments are rendered.
+
+        It returns the data for the comments snippet.
+
+        This extension point can be useful to alter the data before it is
+        rendered, to prevent a display based on pkg_dict information or to
+        even use a different user and/or discourse instance based on the
+        pkg_dict.
+
+        :param data: a dict containing ``topic_id``, ``discourse_url`` and 
+                     ``discourse_username``
+        :type data: dict
+        :param pkg_dict: the information of the current dataset
+        :type pkg_dict: dict
+
+
+        :returns: A data dict containing the following keys:
+                    * ``topic_id``: identifier of the topic on discourse,
+                      provide an empty value to not display any topic
+                    * ``discourse_url``: URL of the discourse instance
+                    * ``discourse_username``: username of the discourse user
+        :rtype: dict
+        '''
+        return data

--- a/ckanext/discourse/plugin.py
+++ b/ckanext/discourse/plugin.py
@@ -8,6 +8,7 @@ import pylons
 import json
 from ckan.plugins.toolkit import asbool
 from ckan.common import g
+from ckanext.discourse.interfaces import IDiscourse
 
 import logging
 
@@ -172,6 +173,9 @@ class DiscoursePlugin(plugins.SingletonPlugin):
         data = {'topic_id' : discourse_topic,
             'discourse_url' : cls.discourse_url,
             'discourse_username' : cls.discourse_username }
+
+        for plugin in p.PluginImplementations(IDiscourse):
+            data = plugin.before_render_comments(data, pkg_dict)
 
         if cls.discourse_debug:
             data['pkg_dict'] = json.dumps(pkg_dict, indent=3)


### PR DESCRIPTION
I propose this interface to enable other extensions to extend the functionality of this plugin. I want to use it in a project to only enable the discourse integration for certain organizations.